### PR TITLE
Fix various references to Linux

### DIFF
--- a/jade/connecting.rst
+++ b/jade/connecting.rst
@@ -3,9 +3,9 @@
 Connecting to the cluster using SSH
 ===================================
 
-To log onto the JADE cluster you must use `SSH <https://en.wikipedia.org/wiki/Secure_Shell>`_, which is a common way of remotely logging in to computers running the Linux operating system.
+To log onto the JADE cluster you must use `SSH <https://en.wikipedia.org/wiki/Secure_Shell>`_, which is a common way of remotely logging in to computers running the GNU/Linux operating system.
 
-To do this, you need to have a SSH *client* program installed on your machine. macOS and Linux come with a command-line (text-only) SSH client pre-installed.  On Windows there are various graphical SSH clients you can use, including *MobaXTerm*.
+To do this, you need to have a SSH *client* program installed on your machine. macOS and GNU/Linux come with a command-line (text-only) SSH client pre-installed.  On Windows there are various graphical SSH clients you can use, including *MobaXTerm*.
 
 
 SSH client software on Windows
@@ -28,17 +28,17 @@ Click *Start local terminal* and if you see something like the following then pl
 Running commands from a terminal (from the command-line) may initially be
 unfamiliar to Windows users but this is the recommended approach for
 running commands on ShARC and Iceberg as
-it is the idiomatic way of interfacing with the Linux clusters.
+it is the idiomatic way of interfacing with the GNU/Linux clusters.
 
-SSH client software on Mac OS/X and Linux
+SSH client software on Mac OS/X and GNU/Linux
 -----------------------------------------
 
-Linux and macOS (OS X) both typically come with a command-line SSH client pre-installed.
+GNU/Linux and macOS (OS X) both typically come with a command-line SSH client pre-installed.
 
 If you are using macOS and want to be able to run graphical applications on the clusters then
 you need to install the latest version of the `XQuartz <https://www.xquartz.org/>`_ *X Windows server*.
 
-Open a terminal (e.g. *Gnome Terminal* on Linux or *Terminal* on macOS) and then go to :ref:`ssh-connection`.
+Open a terminal (e.g. *Gnome Terminal* on GNU/Linux or *Terminal* on macOS) and then go to :ref:`ssh-connection`.
 
 .. _ssh-connection:
 

--- a/jade/modules.rst
+++ b/jade/modules.rst
@@ -6,7 +6,7 @@ The ``module`` tool
 Introduction
 ------------
 
-The Linux operating system makes extensive use of the *working environment*, which is a collection of individual environment variables.  An environment variable is a named object in the Linux shell that contains information used by one or more applications; two of the most used such variables are ``$HOME``, which defines a user's home directory name, and ``$PATH``, which represents a list paths to different executables.  A large number of environment variables are already defined when a Linux shell is open but the environment can be customised, either by defining new environment variables relevant to certain applications or by modifying existing ones (e.g. adding a new path to ``$PATH``).
+The GNU/Linux operating system makes extensive use of the *working environment*, which is a collection of individual environment variables.  An environment variable is a named object in a shell that contains information used by one or more applications; two of the most used such variables are ``$HOME``, which defines a user's home directory name, and ``$PATH``, which represents a list paths to different executables.  A large number of environment variables are already defined when a shell is open but the environment can be customised, either by defining new environment variables relevant to certain applications or by modifying existing ones (e.g. adding a new path to ``$PATH``).
 
 ``module`` is a Software Environment Management tool, which is used to manage the working environment in preparation for running the applications installed on JADE.  By loading the module for a certain installed application, the environment variables that are relevant for that application are automatically defined or modified.
 

--- a/jade/scheduler/build-test.rst
+++ b/jade/scheduler/build-test.rst
@@ -90,7 +90,7 @@ In addition to the above commands, the table below gives two more commands that 
 Preparing a submission script
 -----------------------------
 
-A submission script is a Linux shell script that
+A submission script is a shell script that
 
 * describes the processing to carry out (*e.g.* the application, its input and output, etc.) and
 * requests computer resources (number of GPUs, amount of memory, etc.) to use for processing.
@@ -129,7 +129,7 @@ Supposing the application run is called ``myCode`` and takes no command line arg
   # run the application
   myCode
 
-The script starts with ``#!/bin/bash`` (also called a shebang), which makes the submission script a Linux bash script.
+The script starts with ``#!/bin/bash`` (also called a shebang), which makes the submission script a GNU bash script.
 
 The script continues with a series of lines starting with ``#``, which represent bash script comments.  For Slurm, the lines starting with ``#SBATCH`` are directives that request job scheduling resources.  (Note: it is important that you put all the directives at the top of a script, before any other commands; any ``#SBATCH`` directive coming after a bash script command is ignored!)
 
@@ -141,7 +141,7 @@ The name the job is identified by in the queue can be specified too with ``#SBAT
 
 Lastly, an email notification is sent if an address is specified with ``#SBATCH --mail-user=<email_address>``.  The notification options can be set with ``#SBATCH --mail-type=<type>``, where ``<type>`` may be ``BEGIN``, ``END``, ``FAIL``, ``REQUEUE`` or ``ALL`` (for any change of job state).
 
-The final part of a script is normal Linux bash script and describes the set of operations to follow as part of the job.  The job starts in the same folder where it was submitted (unless an alternative path is specified), and with the same environment variables (modules, etc.) that the user had at the time of the submission.  In this example, this final part only involves invoking the ``myCode`` application executable.
+The final part of a script is normal GNU bash script and describes the set of operations to follow as part of the job.  The job starts in the same folder where it was submitted (unless an alternative path is specified), and with the same environment variables (modules, etc.) that the user had at the time of the submission.  In this example, this final part only involves invoking the ``myCode`` application executable.
 
 
 Submitting jobs with the command sbatch
@@ -217,7 +217,7 @@ Some useful command line options for ``squeue`` include:
 * ``-j`` for showing information regarding a particular job ID, *e.g.*  ``squeue -j 7890``;
 * ``--start`` to report  the  expected  start  time  of pending jobs.
 
-Read all the options for squeue on the Linux manual using the command ``man squeue``, including how to personalize the information to be displayed.
+Read all the options for squeue on the man page squeue(1) using the command ``man squeue``, including how to personalize the information to be displayed.
 
 
 Deleting jobs with the command scancel

--- a/jade/scheduler/index.rst
+++ b/jade/scheduler/index.rst
@@ -88,7 +88,7 @@ In addition to the above commands, the table below gives two more commands that 
 Preparing a submission script
 -----------------------------
 
-A submission script is a Linux shell script that
+A submission script is a bash script that
 
 * describes the processing to carry out (*e.g.* the application, its input and output, etc.) and
 * requests computer resources (number of GPUs, amount of memory, etc.) to use for processing.
@@ -127,7 +127,7 @@ Supposing the application run is called ``myCode`` and takes no command line arg
   # run the application
   myCode
 
-The script starts with ``#!/bin/bash`` (also called a shebang), which makes the submission script a Linux bash script.
+The script starts with ``#!/bin/bash`` (also called a shebang), which makes the submission script a GNU bash script.
 
 The script continues with a series of lines starting with ``#``, which represent bash script comments.  For Slurm, the lines starting with ``#SBATCH`` are directives that request job scheduling resources.  (Note: it is important that you put all the directives at the top of a script, before any other commands; any ``#SBATCH`` directive coming after a bash script command is ignored!)
 
@@ -139,7 +139,7 @@ The name the job is identified by in the queue can be specified too with ``#SBAT
 
 Lastly, an email notification is sent if an address is specified with ``#SBATCH --mail-user=<email_address>``.  The notification options can be set with ``#SBATCH --mail-type=<type>``, where ``<type>`` may be ``BEGIN``, ``END``, ``FAIL``, ``REQUEUE`` or ``ALL`` (for any change of job state).
 
-The final part of a script is normal Linux bash script and describes the set of operations to follow as part of the job.  The job starts in the same folder where it was submitted (unless an alternative path is specified), and with the same environment variables (modules, etc.) that the user had at the time of the submission.  In this example, this final part only involves invoking the ``myCode`` application executable.
+The final part of a script is normal GNU bash script and describes the set of operations to follow as part of the job.  The job starts in the same folder where it was submitted (unless an alternative path is specified), and with the same environment variables (modules, etc.) that the user had at the time of the submission.  In this example, this final part only involves invoking the ``myCode`` application executable.
 
 
 Submitting jobs with the command sbatch
@@ -215,7 +215,7 @@ Some useful command line options for ``squeue`` include:
 * ``-j`` for showing information regarding a particular job ID, *e.g.*  ``squeue -j 7890``;
 * ``--start`` to report  the  expected  start  time  of pending jobs.
 
-Read all the options for squeue on the Linux manual using the command ``man squeue``, including how to personalize the information to be displayed.
+Read all the options for squeue on the man page squeue(1) using the command ``man squeue``, including how to personalize the information to be displayed.
 
 
 Deleting jobs with the command scancel


### PR DESCRIPTION
It is the GNU operating system that we are using, the polite and
politically correct name for the bundle is GNU/Linux.

- replace Linux by GNU/Linux where appropriate
- fix a reference to the "Linux manual", refer to the slurm manual.
- replace "Linux bash" by "GNU bash" giving the credit to Brian Fox [1].

[1] https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29