### PR TITLE
Add software/git to the table of contents

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -37,3 +37,4 @@ The following are the available applications, libraries and development tools on
     machine-learning/index
     molecular-dynamics/index
     python
+    git

--- a/software/python.rst
+++ b/software/python.rst
@@ -36,12 +36,12 @@ Using conda Python
 
 Conda version ``4.3.30`` is available for both Python 2 and 3 and can be loaded through provided module files: ::
 
-  apps/python2/anaconda
-  apps/python3/anaconda
+  python2/anaconda
+  python3/anaconda
 
 Use the ``module load`` command to load a particular Anaconda Python version e.g. Anaconda for Python 3: ::
 
-  module load apps/python3/anaconda
+  module load python3/anaconda
 
 
 Using conda Environments


### PR DESCRIPTION
Follow up on #25 to make the `software/git` page visible in the table of contents, otherwise it's not discoverable in any reasonable way